### PR TITLE
bugfix:flitter3 data_table2 outside container need

### DIFF
--- a/lib/screens/dashboard/components/recent_files.dart
+++ b/lib/screens/dashboard/components/recent_files.dart
@@ -27,6 +27,7 @@ class RecentFiles extends StatelessWidget {
           ),
           SizedBox(
             width: double.infinity,
+            height: 400,
             child: DataTable2(
               columnSpacing: defaultPadding,
               minWidth: 600,


### PR DESCRIPTION
height

might be this issue [cannot run this code with flutter 3.0.5 #51](https://github.com/abuanwar072/Flutter-Responsive-Admin-Panel-or-Dashboard/issues/51)